### PR TITLE
fix(config): update base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: './', // This ensures assets are loaded correctly on GitHub Pages
+  base: '/user-management/', // Use your repo name
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
The base path was changed from './' to '/user-management/' to ensure proper asset loading when deployed to GitHub Pages under a repository name.