### PR TITLE
refactor(vite): remove build config and base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/user-management/', // Use your repo name
   optimizeDeps: {
     exclude: ['lucide-react'],
-  },
-  build: {
-    outDir: 'dist',
-    assetsDir: 'assets',
   },
 });


### PR DESCRIPTION
The build configuration and base path are no longer needed as we're moving to a different deployment strategy. The default Vite build output directory and assets handling will be used instead.